### PR TITLE
Fix lotsa/lotsa.github.io#2: Indianapolis fragment ids

### DIFF
--- a/blog/_posts/2015-06-10-june-news.md
+++ b/blog/_posts/2015-06-10-june-news.md
@@ -40,7 +40,7 @@ Contra dancing with the [Louisville Country Dancers][] every Monday evening at [
 
 <p style="text-align:center">❧</p>
 
-<hgroup id="vernon">
+<hgroup id="indianapolis">
 <h3>Friday, June 12th</h3>
 <h2>Square Dance at White Pine Wilderness Academy with the New Hoosier Broadcasters, Alex Udis calling</h2>
 </hgroup>


### PR DESCRIPTION
Indianapolis section had "#vernon" id, not "#indianapolis". This also was a problem for the Vernon link in the event list.